### PR TITLE
Fix Duplicate Deadlife Dust Label

### DIFF
--- a/Defs/GasDefs.xml
+++ b/Defs/GasDefs.xml
@@ -26,7 +26,7 @@
 
 	<PerformanceFish.GasDef>
 		<defName>DeadLifeDust</defName>
-		<label>dead life dust</label>
+		<label>deadlife dust</label>
 		<dissipationRate>3</dissipationRate>
 		<diffuses>true</diffuses>
 		<color>(3,13,51)</color>

--- a/Source/PerformanceFish/GasDef.cs
+++ b/Source/PerformanceFish/GasDef.cs
@@ -20,6 +20,9 @@ public class GasDef : Def
 			GasType.BlindSmoke => GasDefOf.BlindSmoke,
 			GasType.RotStink => GasDefOf.RotStink,
 			GasType.ToxGas => GasDefOf.ToxGas,
+#if !V1_4
+			GasType.DeadlifeDust => GasDefOf.DeadLifeDust,
+#endif
 			_ => null
 		};
 }

--- a/Source/PerformanceFish/GasGridOptimization.cs
+++ b/Source/PerformanceFish/GasGridOptimization.cs
@@ -28,9 +28,9 @@ public sealed class GasGridOptimization : ClassWithFishPrepatches
 {
 	private const int START_INDEX
 #if V1_4
-			= 3;
+		= 3;
 #else
-	= 4;
+		= 4;
 #endif
 
 	public sealed class SetDirectPatch : FishPrepatch

--- a/Source/PerformanceFish/GasGridOptimization.cs
+++ b/Source/PerformanceFish/GasGridOptimization.cs
@@ -550,7 +550,7 @@ public sealed class GasGridOptimization : ClassWithFishPrepatches
 			var gasGrids = map.gasGrid.ParallelGasGrids();
 			var cellIndex = new CellIndex(cell, map);
 
-			for (var i = 3; i < gasGrids.Length; i++)
+			for (var i = 4; i < gasGrids.Length; i++)
 			{
 				var gasGrid = gasGrids[i];
 				if (!gasGrid.AnyGasAt(cellIndex))

--- a/Source/PerformanceFish/GasGridOptimization.cs
+++ b/Source/PerformanceFish/GasGridOptimization.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 bradson
+﻿// Copyright (c) 2023 bradson
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -500,7 +500,7 @@ public sealed class GasGridOptimization : ClassWithFishPrepatches
 		{
 			var gasDefs = DefDatabase<GasDef>.AllDefsListForReading;
 
-			for (var i = 3; i < gasDefs.Count; i++)
+			for (var i = START_INDEX; i < gasDefs.Count; i++)
 			{
 				var gasDef = gasDefs[i];
 				

--- a/Source/PerformanceFish/GasGridOptimization.cs
+++ b/Source/PerformanceFish/GasGridOptimization.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 bradson
+// Copyright (c) 2023 bradson
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -26,6 +26,13 @@ namespace PerformanceFish;
 
 public sealed class GasGridOptimization : ClassWithFishPrepatches
 {
+	private const int START_INDEX
+#if V1_4
+			= 3;
+#else
+	= 4;
+#endif
+
 	public sealed class SetDirectPatch : FishPrepatch
 	{
 		public override bool ShowSettings => false;
@@ -550,7 +557,7 @@ public sealed class GasGridOptimization : ClassWithFishPrepatches
 			var gasGrids = map.gasGrid.ParallelGasGrids();
 			var cellIndex = new CellIndex(cell, map);
 
-			for (var i = 4; i < gasGrids.Length; i++)
+			for (var i = START_INDEX; i < gasGrids.Length; i++)
 			{
 				var gasGrid = gasGrids[i];
 				if (!gasGrid.AnyGasAt(cellIndex))


### PR DESCRIPTION
`GasGridOptimization.MouseOverReadOutOnGui` starts iterating through the gas grids at index 3, causing deadlife dust to be labelled twice.

With patch enabled:

![Image](https://github.com/user-attachments/assets/185a0b4f-0f05-42c2-98c0-9845c8ebe31d)

> *The text differences are due to vanilla using `"DeadlifeDust".Translate()` and the patched method using `LabelCap`*

With patch disabled:

![Image](https://github.com/user-attachments/assets/910d71c6-c668-4269-b81e-7d075d9560fe)