### PR TITLE
Deduplicate the list of haulables if the cache is still dirty after an update

### DIFF
--- a/Source/PerformanceFish/Listers/Haulables.cs
+++ b/Source/PerformanceFish/Listers/Haulables.cs
@@ -199,6 +199,16 @@ public sealed class Haulables : ClassWithFishPrepatches
 			
 			for (var i = haulables.Count; i-- > 0;)
 				ContainedThings.Add(haulables[i].GetKey());
+			if (IsDirty(haulables))
+			{
+				Verse.Log.Warning("Dirty cache after update. Deduplicating the list of haulables.");
+				FishSet<Thing> haulablesDeduped = [];
+				foreach (var thing in haulables)
+					haulablesDeduped.Add(thing);
+				haulables.Clear();
+				foreach (var thing in haulablesDeduped)
+					haulables.Add(thing);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Some mods occasionally leave duplicates in the list of haulables. As a result, the counts in the list and the cache are never equal, invalidating the cache as soon as it's made and ruining performance. 
This should handle such situations a lot more gracefully